### PR TITLE
REPORTGEN-728: Full Detailed Report.xslx (and all Full Detailed Repor…

### DIFF
--- a/CastReporting.BLL.Core/BO/ApplicationBLL.cs
+++ b/CastReporting.BLL.Core/BO/ApplicationBLL.cs
@@ -180,6 +180,12 @@ namespace CastReporting.BLL
                 taskStandardTags.Wait();
             }
 
+            using (CastDomainBLL castDomainBll = new CastDomainBLL(connection))
+            {
+                CastDomain domain = castDomainBll.GetDomains().FirstOrDefault(_=>_.DomainId.Equals(application.DomainId));
+                application.DomainType = domain?.DBType;
+            }
+
         }
        
     }

--- a/CastReporting.Domain.Core/DataObject/CRObject.cs
+++ b/CastReporting.Domain.Core/DataObject/CRObject.cs
@@ -57,6 +57,8 @@ namespace CastReporting.Domain
 
         public string DomainId => Href.Split('/').FirstOrDefault();
 
+        public string DomainType { get; set; }
+
         #region METHODS
         public override string ToString()
         {

--- a/CastReporting.Reporting.Core/Block/Table/QualityRuleViolations.cs
+++ b/CastReporting.Reporting.Core/Block/Table/QualityRuleViolations.cs
@@ -29,6 +29,20 @@ namespace CastReporting.Reporting.Block.Table
 
             int nbCol = 1;
             rowData.Add(Labels.ObjectsInViolationForRule + " " + ruleName);
+
+            if (reportData.Application.DomainType.Equals("AAD"))
+            {
+                rowData.Add(Labels.BadDomain);
+                return new TableDefinition
+                {
+                    HasRowHeaders = false,
+                    HasColumnHeaders = true,
+                    NbRows = rowData.Count,
+                    NbColumns = 1,
+                    Data = rowData
+                };
+            }
+
             if (hasPri)
             {
                 nbCol++;

--- a/CastReporting.Reporting.Core/Block/Table/QualityRuleViolationsBookmarks.cs
+++ b/CastReporting.Reporting.Core/Block/Table/QualityRuleViolationsBookmarks.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using CastReporting.BLL;
 using CastReporting.Reporting.Atrributes;
 using CastReporting.Reporting.Builder.BlockProcessing;
 using CastReporting.Reporting.ReportingModel;
@@ -29,6 +30,19 @@ namespace CastReporting.Reporting.Block.Table
 
             rowData.Add(Labels.ObjectsInViolationForRule + " " + ruleName);
             cellidx++;
+
+            if (reportData.Application.DomainType.Equals("AAD"))
+            {
+                rowData.Add(Labels.BadDomain);
+                return new TableDefinition
+                {
+                    HasRowHeaders = false,
+                    HasColumnHeaders = true,
+                    NbRows = rowData.Count,
+                    NbColumns = 1,
+                    Data = rowData
+                };
+            }
 
             IEnumerable<Violation> results = reportData.SnapshotExplorer.GetViolationsListIDbyBC(reportData.CurrentSnapshot.Href, ruleId, bcId, nbLimitTop, "$all");
             if (results != null)

--- a/CastReporting.Reporting.Core/Block/Table/QualityTagsRulesEvolution.cs
+++ b/CastReporting.Reporting.Core/Block/Table/QualityTagsRulesEvolution.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
  *
  */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cast.Util.Log;
@@ -201,6 +203,10 @@ namespace CastReporting.Reporting.Block.Table
             {
                 var dataRow = headers.CreateDataRow();
                 dataRow.Set(0, Labels.NoRules);
+                for (int i=1; i < headers.Count; i++)
+                {
+                    dataRow.Set(i, string.Empty);
+                }
                 data.AddRange(dataRow);
             }
 

--- a/CastReporting.Reporting.Core/Block/Table/RulesListViolationsBookmarks.cs
+++ b/CastReporting.Reporting.Core/Block/Table/RulesListViolationsBookmarks.cs
@@ -61,6 +61,19 @@ namespace CastReporting.Reporting.Block.Table
                 cellidx++;
             }
 
+            if (reportData.Application.DomainType.Equals("AAD"))
+            {
+                rowData.Add(Labels.BadDomain);
+                return new TableDefinition
+                {
+                    HasRowHeaders = false,
+                    HasColumnHeaders = displayHeader,
+                    NbRows = rowData.Count,
+                    NbColumns = 1,
+                    Data = rowData
+                };
+            }
+
             if (qualityRules.Count > 0)
             {
                 const string bcId = "60017";

--- a/CastReporting.Reporting.Core/Block/Table/RulesListViolationsBookmarksTable.cs
+++ b/CastReporting.Reporting.Core/Block/Table/RulesListViolationsBookmarksTable.cs
@@ -39,6 +39,20 @@ namespace CastReporting.Reporting.Block.Table
             }
 
             headers.Append(Labels.RuleName);
+
+            if (reportData.Application.DomainType.Equals("AAD"))
+            {
+                rowData.Add(Labels.BadDomain);
+                return new TableDefinition
+                {
+                    HasRowHeaders = false,
+                    HasColumnHeaders = displayHeader,
+                    NbRows = rowData.Count,
+                    NbColumns = 1,
+                    Data = rowData
+                };
+            }
+
             headers.Append(Labels.ObjectName);
             headers.Append(Labels.IFPUG_ObjectType);
             headers.Append(Labels.Status);

--- a/CastReporting.Reporting.Core/Languages/Labels.DE-de.resx
+++ b/CastReporting.Reporting.Core/Languages/Labels.DE-de.resx
@@ -789,4 +789,7 @@
   <data name="StartLine" xml:space="preserve">
     <value>Startzeile</value>
   </data>
+  <data name="BadDomain" xml:space="preserve">
+    <value>Die Anwendung wird aus einer AAD-Domäne geladen, so dass keine Informationen verfügbar sind.</value>
+  </data>
 </root>

--- a/CastReporting.Reporting.Core/Languages/Labels.Designer.cs
+++ b/CastReporting.Reporting.Core/Languages/Labels.Designer.cs
@@ -277,6 +277,15 @@ namespace CastReporting.Reporting.Core.Languages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Application is loaded from an AAD domain, so no information is available..
+        /// </summary>
+        public static string BadDomain {
+            get {
+                return ResourceManager.GetString("BadDomain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Business criterion name.
         /// </summary>
         public static string BusinessCriterionName {

--- a/CastReporting.Reporting.Core/Languages/Labels.ES-es.resx
+++ b/CastReporting.Reporting.Core/Languages/Labels.ES-es.resx
@@ -789,4 +789,7 @@
   <data name="StartLine" xml:space="preserve">
     <value>Línea de partida</value>
   </data>
+  <data name="BadDomain" xml:space="preserve">
+    <value>La aplicación se carga desde un dominio AAD, por lo que no hay información disponible.</value>
+  </data>
 </root>

--- a/CastReporting.Reporting.Core/Languages/Labels.FR-fr.resx
+++ b/CastReporting.Reporting.Core/Languages/Labels.FR-fr.resx
@@ -789,4 +789,7 @@
   <data name="StartLine" xml:space="preserve">
     <value>Ligne de début</value>
   </data>
+  <data name="BadDomain" xml:space="preserve">
+    <value>L’application est chargée à partir d’un domaine AAD, donc aucune information n’est disponible.</value>
+  </data>
 </root>

--- a/CastReporting.Reporting.Core/Languages/Labels.IT-it.resx
+++ b/CastReporting.Reporting.Core/Languages/Labels.IT-it.resx
@@ -789,4 +789,7 @@
   <data name="StartLine" xml:space="preserve">
     <value>Linea di partenza</value>
   </data>
+  <data name="BadDomain" xml:space="preserve">
+    <value>L'applicazione viene caricata da un dominio AAD, quindi non sono disponibili informazioni.</value>
+  </data>
 </root>

--- a/CastReporting.Reporting.Core/Languages/Labels.resx
+++ b/CastReporting.Reporting.Core/Languages/Labels.resx
@@ -789,4 +789,7 @@
   <data name="StartLine" xml:space="preserve">
     <value>Start Line</value>
   </data>
+  <data name="BadDomain" xml:space="preserve">
+    <value>Application is loaded from an AAD domain, so no information is available.</value>
+  </data>
 </root>

--- a/CastReporting.Reporting.Core/Languages/Labels.zh-CN.resx
+++ b/CastReporting.Reporting.Core/Languages/Labels.zh-CN.resx
@@ -789,4 +789,7 @@
   <data name="StartLine" xml:space="preserve">
     <value>起点线</value>
   </data>
+  <data name="BadDomain" xml:space="preserve">
+    <value>应用程序从 AAD 域加载，因此没有可用的信息</value>
+  </data>
 </root>


### PR DESCRIPTION
…ts) gives error at generation time: Value cannot be null. (Parameter 'source')